### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,4 @@
-Revision history for Perl extension Pod::L10N.
+Revision history for Perl module Pod::L10N
 
 {{$NEXT}}
 
@@ -7,51 +7,52 @@ Revision history for Perl extension Pod::L10N.
 	- change base to Pod::Simple
 	- change release base to Minilla-based
 
-0.07    Thu Jul  22 17:52:18 JST 2010
+0.07 2010-07-22 17:52:18 JST
 
 	- fix bug that head with X<> cannot substitute correctly
 
-0.06    Thu Jul   1 20:19:50 JST 2010
+0.06 2010-07-01 20:19:50 JST
 
 	- adjust test for Non-Unix
 
-0.05    Thu Jun  19 23:40:42 JST 2009
+0.05 2009-06-19 23:40:42 JST
 
 	- adjust test for pre-5.8
 	- more support for =encoding
 	- fix bug about headings with formattings codes
 
-0.04    Thu Jun  5 18:53:26 JST 2009
+0.04 2009-06-05 18:53:26 JST
 
 	- add pod
 
-0.03_02 Thu Jun  5 00:57:10 JST 2009
+0.03_02 2009-06-05 00:57:10 JST
 
 	- eliminate some warnings
 
-0.03_01 Thu Jun  4 00:23:12 JST 2009
+0.03_01 2009-06-04 00:23:12 JST
 
 	- change base to Pod::Html 1.09_04
 	- add tests from Pod::Html
 
-0.03    Thu May 28 15:53:36 JST 2009
+0.03 2009-05-28 15:53:36 JST
 
 	- release
 
-0.02_02 Thu May 28 00:35:52 JST 2009
+0.02_02 2009-05-28 00:35:52 JST
 
 	- skip some tests
 
-0.02_01 Wed May 27 17;11:52 JST 2009
+0.02_01 2009-05-27 17:11:52 JST
 
 	- adjust some tests
 
-0.02    Wed May 27 02:28:18 JST 2009
+0.02 2009-05-27 02:28:18 JST
 
 	- add =item-substitution
 	- suppress link to non-exist modules
 	- add some tests
 
-0.01    Tue Jul 30 02:40:54 JST 2008
+0.01 2008-07-30 02:40:54 JST
 
 	- initial release (without tests)
+


### PR DESCRIPTION
Hi,

I've reformatted your Changes file according to the spec in CPAN::Changes::Spec. This was basically changing the dates to ISO 8601 date format.

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's [CPAN::Changes Kwalitee Service](http://changes.cpanhq.org), which is where I saw your module listed :-)

Cheers,
Neil

PS I'm doing this because I'm on a quest to help improve CPAN:

> http://questhub.io/realm/perl/quest/51f0337718ba7d3959000086
