### PR TITLE
fix test failure on Pod::Simple >= 3.46

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for Perl module Pod::L10N
 {{$NEXT}}
 
 	- upgrade upstream to 1.33 (5.36.0-based)
+	- fix test failure on Pod::Simple 3.46 or later
 
 1.07 2022-09-16T09:45:36Z
 

--- a/t/htmlview.t
+++ b/t/htmlview.t
@@ -107,7 +107,7 @@ my $module = My::Module-&gt;new();</code></pre>
 
 <p>The bar item.</p>
 
-<ul>
+<blockquote>
 
 <p>This is a list within a list</p>
 
@@ -119,7 +119,7 @@ my $module = My::Module-&gt;new();</code></pre>
 
 <p>The waz item.</p>
 
-</ul>
+</blockquote>
 
 </dd>
 <dt id="baz">baz</dt>

--- a/t/lib/Testing.pm
+++ b/t/lib/Testing.pm
@@ -546,6 +546,9 @@ sub _set_expected_html {
         $expect =~ s{(intermediate text</p>)}{$1\n\n}m;
         $expect =~ s/\n\n(some text)/$1/m;
     }
+    if (Pod::Simple->VERSION < 3.46) {
+        $expect =~ s/blockquote/ul/mg;
+    }
     return $expect;
 }
 

--- a/t/poderr.t
+++ b/t/poderr.t
@@ -55,7 +55,7 @@ __DATA__
 
 <p>Test POD ERROR section</p>
 
-<ul>
+<blockquote>
 
 <p>This text is not allowed</p>
 
@@ -67,7 +67,7 @@ __DATA__
 
 <p>The waz item.</p>
 
-</ul>
+</blockquote>
 
 <h1 id="POD-ERRORS">POD ERRORS</h1>
 

--- a/t/podnoerr.t
+++ b/t/podnoerr.t
@@ -55,7 +55,7 @@ __DATA__
 
 <p>Test POD ERROR section</p>
 
-<ul>
+<blockquote>
 
 <p>This text is not allowed</p>
 
@@ -67,7 +67,7 @@ __DATA__
 
 <p>The waz item.</p>
 
-</ul>
+</blockquote>
 
 
 </body>


### PR DESCRIPTION
From Pod::Simple 3.46, `=over` without `=item` is rendered as a blockquote.

fix #3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - Perlモジュールのリビジョン履歴に、特定バージョンでのテスト修正についての記載を追加しました。

- **バグ修正**
  - テスト出力のHTML構造を一部修正し、`<ul>`から`<blockquote>`への変換を行いました。これにより、Pod::Simpleのバージョンによるテスト失敗が解消されます。
  - Pod::Simpleのバージョンが3.46未満の場合に、期待されるHTML出力を自動的に調整する処理を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->